### PR TITLE
Added LayoutValueResolve BuildContext extension

### DIFF
--- a/lib/src/value.dart
+++ b/lib/src/value.dart
@@ -65,6 +65,10 @@ abstract class LayoutValue<T> {
   }
 }
 
+extension LayoutValueResolve on BuildContext {
+  T resolve<T>(LayoutValue<T> value) => value.resolve(this);
+}
+
 class ConstantLayoutValue<T> extends LayoutValue<T> {
   final T value;
 


### PR DESCRIPTION
This simple feature adds the ability to resolve LayoutValue, using an extension on `BuildContext`, thus making this feature syntactically similar to other package's `BuildContext` extensions, such as `context.watch()` or `context.read()`.

This

```
BreakpointValue(xs: 0.0, sm: 10.0).resolve(context)
```
is the same as
```
context.resolve(BreakpointValue(xs: 0.0, sm: 10.0))
```
