### PR TITLE
Added gutter separate list method

### DIFF
--- a/lib/src/gutter.dart
+++ b/lib/src/gutter.dart
@@ -9,7 +9,7 @@ class Gutter extends StatelessWidget {
     Key? key,
   ]) : super(key: key);
 
-  static List<Widget> separateList({
+  static List<Widget> separateChildren({
     required List<Widget> children,
     required double extent,
   }) =>

--- a/lib/src/gutter.dart
+++ b/lib/src/gutter.dart
@@ -11,7 +11,7 @@ class Gutter extends StatelessWidget {
 
   static List<Widget> separateChildren({
     required List<Widget> children,
-    required double extent,
+    double? extent,
   }) =>
       children.separate(extent);
 
@@ -35,10 +35,10 @@ class SliverGutter extends StatelessWidget {
 }
 
 extension ListGutter on List<Widget> {
-  List<Widget> separate(double extend) => length <= 1
+  List<Widget> separate(double? extend) => length <= 1
       ? this
       : sublist(1).fold(
           [first],
-          (r, element) => [...r, Gap(extend), element],
+          (r, element) => [...r, Gutter(extend), element],
         );
 }

--- a/lib/src/gutter.dart
+++ b/lib/src/gutter.dart
@@ -9,6 +9,12 @@ class Gutter extends StatelessWidget {
     Key? key,
   ]) : super(key: key);
 
+  static List<Widget> separateList({
+    required List<Widget> children,
+    required double extent,
+  }) =>
+      children.separate(extent);
+
   @override
   Widget build(BuildContext context) {
     return Gap(extent ?? context.layout.gutter);
@@ -26,4 +32,13 @@ class SliverGutter extends StatelessWidget {
   Widget build(BuildContext context) {
     return SliverGap(extent ?? context.layout.gutter);
   }
+}
+
+extension ListGutter on List<Widget> {
+  List<Widget> separate(double extend) => length <= 1
+      ? this
+      : sublist(1).fold(
+          [first],
+          (r, element) => [...r, Gap(extend), element],
+        );
 }


### PR DESCRIPTION
## Connection with issue(s)

Resolves issue #11.

This PR adds the `Gutter.separateChildren()` method and the `ListGutter` extension on `List<Widget>`, solving the mentioned issue.

