### PR TITLE
Change Mixing for AnimatedResize Class

### DIFF
--- a/example/lib/animated_resize.dart
+++ b/example/lib/animated_resize.dart
@@ -9,7 +9,7 @@ class AnimatedResize extends StatefulWidget {
 }
 
 class _AnimatedResizeState extends State<AnimatedResize>
-    with TickerProviderStateMixin {
+    with SingleTickerProviderStateMixin {
   late AnimationController animationController;
 
   @override


### PR DESCRIPTION
you can use `SingleTickerProviderStateMixin` instead `TickerProviderStateMixin`

## Connection with issue(s)

Resolve issue #???

<!-- Required: this reference (one or many) will be closed upon merge. Ideally it has the acceptance criteria and designs for features or fixes related to the work in this Pull Request -->

Connected to #???

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->

## Testing and Review Notes

<!-- Required: steps to take to confirm this works as expected or other guidance for code, UX, and any other reviewers -->

## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

<!-- Add “WIP” to the PR title if pushing up but not complete nor ready for review -->
- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit test
